### PR TITLE
Rename get_item_rect to _edit_get_rect

### DIFF
--- a/spine.cpp
+++ b/spine.cpp
@@ -1231,10 +1231,10 @@ void Spine::_bind_methods() {
 	BIND_CONSTANT(DEBUG_ATTACHMENT_BOUNDING_BOX);
 }
 
-Rect2 Spine::get_item_rect() const {
+Rect2 Spine::_edit_get_rect() const {
 
 	if (skeleton == NULL)
-		return Node2D::get_item_rect();
+		return Node2D::_edit_get_rect();
 
 	float minX = 65535, minY = 65535, maxX = -65535, maxY = -65535;
 	bool attached = false;
@@ -1266,7 +1266,7 @@ Rect2 Spine::get_item_rect() const {
 	}
 
 	int h = maxY - minY;
-	return attached ? Rect2(minX, -minY - h, maxX - minX, h) : Node2D::get_item_rect();
+	return attached ? Rect2(minX, -minY - h, maxX - minX, h) : Node2D::_edit_get_rect();
 }
 
 void Spine::_update_verties_count() {

--- a/spine.h
+++ b/spine.h
@@ -225,7 +225,7 @@ public:
 
 	//void advance(float p_time);
 
-	virtual Rect2 get_item_rect() const;
+	virtual Rect2 _edit_get_rect() const;
 
 	Spine();
 	virtual ~Spine();


### PR DESCRIPTION
Following commit 8d1f2b1 on godot master, Node2D::get_item_rect() is now known as Node2D::_edit_get_rect().
This PR handles similar refactoring for the module and ensures proper compilation against latest godot's master branch.