### PR TITLE
Rename set_z to set_z_index

### DIFF
--- a/spine.cpp
+++ b/spine.cpp
@@ -561,7 +561,7 @@ void Spine::_notification(int p_what) {
 
 			// add fx node as child
 			fx_node->connect("draw", this, "_on_fx_draw");
-			fx_node->set_z(1);
+			fx_node->set_z_index(1);
 			fx_node->set_z_as_relative(false);
 			add_child(fx_node);
 


### PR DESCRIPTION
Following commit eaf100e on godot master, Node2D::set_z() is now known as Node2D::set_z_index().
This PR handles similar refactoring for the module and ensures proper compilation against latest godot's master branch.