### PR TITLE
Add method set_default_mix to... set default mix value

### DIFF
--- a/spine.cpp
+++ b/spine.cpp
@@ -655,6 +655,12 @@ bool Spine::has_animation(const String &p_name) {
 	return animation != NULL;
 }
 
+void Spine::set_default_mix(real_t p_duration) {
+
+	ERR_FAIL_COND(state == NULL);
+	state->data->defaultMix = p_duration;
+}
+
 void Spine::mix(const String &p_from, const String &p_to, real_t p_duration) {
 
 	ERR_FAIL_COND(state == NULL);
@@ -1158,6 +1164,7 @@ void Spine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_animation_names"), &Spine::get_animation_names);
 	ClassDB::bind_method(D_METHOD("has_animation", "name"), &Spine::has_animation);
 
+	ClassDB::bind_method(D_METHOD("set_default_mix", "duration"), &Spine::set_default_mix);
 	ClassDB::bind_method(D_METHOD("mix", "from", "to", "duration"), &Spine::mix, 0);
 	ClassDB::bind_method(D_METHOD("play", "name", "cunstom_scale", "loop", "track", "delay"), &Spine::play, 1.0f, false, 0, 0);
 	ClassDB::bind_method(D_METHOD("add", "name", "cunstom_scale", "loop", "track", "delay"), &Spine::add, 1.0f, false, 0, 0);

--- a/spine.h
+++ b/spine.h
@@ -146,6 +146,7 @@ public:
 	Array get_animation_names() const;
 
 	bool has_animation(const String& p_name);
+	void set_default_mix(real_t p_duration);
 	void mix(const String& p_from, const String& p_to, real_t p_duration);
 
 	bool play(const String& p_name, real_t p_cunstom_scale = 1.0f, bool p_loop = false, int p_track = 0, int p_delay = 0);


### PR DESCRIPTION
Pretty much all is written in the title, this PR simply adds the method `set_default_mix` which sets the default value for mixing between animations when no specific mix is set with method `mix`.