### PR TITLE
Add animation duration to properties

### DIFF
--- a/spine.h
+++ b/spine.h
@@ -92,6 +92,8 @@ private:
 	bool debug_attachment_skinned_mesh;
 	bool debug_attachment_bounding_box;
 	String current_animation;
+	float duration; // Handled as a property, but never set in the setter
+	float actual_duration; // Store the actual length of the animation
 	bool loop;
 	String skin;
 
@@ -182,6 +184,9 @@ public:
 	void set_flip_y(bool p_flip);
 	bool is_flip_x() const;
 	bool is_flip_y() const;
+
+	void set_duration(float p_duration);
+	float get_duration() const;
 
 	void set_animation_process_mode(AnimationProcessMode p_mode);
 	AnimationProcessMode get_animation_process_mode() const;


### PR DESCRIPTION
This is useful when an `AnimationPlayer` controls the Spine node
and you need to tell your animation how long it's going to be. With
the wrong duration, the animation will be broken and there's no
better way to check this than having it visible.
    
It would be nicer if it was truly read-only. Now it looks like it
can be edited, though it can't and obviously shouldn't.
