### PR TITLE
Proper fix for building with both Godot 3.0 and 3.1

### DIFF
--- a/spine_batcher.cpp
+++ b/spine_batcher.cpp
@@ -85,8 +85,10 @@ void SpineBatcher::Elements::draw(RID ci) {
 		p_points,
 		p_colors,
 		p_uvs,
+#if (VERSION_MAJOR == 3 && VERSION_MINOR >= 1)
 		Vector<int>(),
 		Vector<float>(),
+#endif
 		texture->get_rid()
 	);
 


### PR DESCRIPTION
As suggested in #13 there is a proper solution for ensuring the code compiles in both versions of Godot.

Please accept this!