### PR TITLE
Make Spine nodes active by default

### DIFF
--- a/spine.cpp
+++ b/spine.cpp
@@ -1338,7 +1338,7 @@ Spine::Spine()
 	autoplay = "";
 	animation_process_mode = ANIMATION_PROCESS_IDLE;
 	processing = false;
-	active = false;
+	active = true;
 	playing = false;
 	forward = true;
 	process_delta = 0;


### PR DESCRIPTION
I noticed that from a usability point of view, it makes sense that the `active` boolean is set.

If it's not, loading a resource and playing an animation will not actually play it, and there's an extra click involved in making it work.

Unless there's a reason I'm missing here, it would be nice to have this merged in :)

Thanks!