### PR TITLE
Spine module would not compile for builds without the editor (tools=no)

### DIFF
--- a/spine.cpp
+++ b/spine.cpp
@@ -1307,6 +1307,7 @@ void Spine::_bind_methods() {
 	BIND_ENUM_CONSTANT(DEBUG_ATTACHMENT_BOUNDING_BOX);
 }
 
+#ifdef TOOLS_ENABLED
 Rect2 Spine::_edit_get_rect() const {
 
 	if (skeleton == NULL)
@@ -1348,6 +1349,7 @@ Rect2 Spine::_edit_get_rect() const {
 bool Spine::_edit_use_rect() const {
 	return skeleton != NULL;
 }
+#endif  // #ifdef TOOLS_ENABLED
 
 void Spine::_update_verties_count() {
 

--- a/spine.h
+++ b/spine.h
@@ -241,8 +241,10 @@ public:
 
 	//void advance(float p_time);
 
+#ifdef TOOLS_ENABLED
 	virtual Rect2 _edit_get_rect() const;
 	virtual bool _edit_use_rect() const;
+#endif
 
 	Spine();
 	virtual ~Spine();


### PR DESCRIPTION
Two methods in spine.cpp can only be compiled if the target build includes the Godot editor. So, a conditional compilation directive allows Spine module to be compiled for builds without the editor.